### PR TITLE
Add capabilities checking/filtering to the driver

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -19,6 +19,36 @@ type Capabilities struct {
 	PH          bool `json:"ph"`
 }
 
+func (c *Capabilities) HasCapabilities(check Capabilities) bool {
+	match := true
+	if check.Input {
+		if !c.Input {
+			match = false
+		}
+	}
+	if check.Output {
+		if !c.Output {
+			match = false
+		}
+	}
+	if check.PWM {
+		if !c.PWM {
+			match = false
+		}
+	}
+	if check.Temperature {
+		if !c.Temperature {
+			match = false
+		}
+	}
+	if check.PH {
+		if !c.PH {
+			match = false
+		}
+	}
+	return match
+}
+
 type Driver interface {
 	io.Closer
 	Metadata() Metadata

--- a/driver.go
+++ b/driver.go
@@ -19,7 +19,7 @@ type Capabilities struct {
 	PH          bool `json:"ph"`
 }
 
-func (c *Capabilities) HasCapabilities(check Capabilities) bool {
+func (c Capabilities) HasCapabilities(check Capabilities) bool {
 	match := true
 	if check.Input {
 		if !c.Input {

--- a/driver_test.go
+++ b/driver_test.go
@@ -4,6 +4,25 @@ import (
 	"testing"
 )
 
+func TestCapabilities_HasCapabilities(t *testing.T) {
+	c1 := Capabilities{
+		Output: true,
+	}
+	c2 := Capabilities{
+		Input: true,
+		Output: true,
+	}
+	if !c1.HasCapabilities(c1) {
+		t.Errorf("capabilities aren't equal")
+	}
+	if !c2.HasCapabilities(c1) {
+		t.Errorf("capabilities aren't a superset")
+	}
+	if c1.HasCapabilities(c2) {
+		t.Errorf("capabilities were a subset")
+	}
+}
+
 func TestDriver(t *testing.T) {
 	var d Driver = NewNoopDriver()
 	if d.Metadata().Name == "" {


### PR DESCRIPTION
Arguably we can also cast the driver to the various interfaces but its
harder to express as an API, so I'm somewhat leaning on keeping this
object anyway.