### PR TITLE
(chore) Convert capability to enum type

### DIFF
--- a/adc.go
+++ b/adc.go
@@ -2,10 +2,11 @@ package hal
 
 type ADCChannel interface {
 	Name() string
-	Set(value float64) error
+	Read() (float64, error)
 }
+
 type ADCDriver interface {
 	Driver
-	ADChannels() []PWMChannel
+	ADCChannels() []ADCChannel
 	ADCChannel(name string) (ADCChannel, error)
 }

--- a/driver.go
+++ b/driver.go
@@ -2,21 +2,32 @@ package hal
 
 import "io"
 
+type Capability int
+
+const (
+	None Capability = iota
+	Input
+	Output
+	PH
+	Temperature
+	PWM
+)
+
 // Metadata represents basic information about a driver
 // for the API response.
 type Metadata struct {
 	Name         string       `json:"name"`
 	Description  string       `json:"description"`
-	Capabilities Capabilities `json:"capabilities"`
+	Capabilities []Capability `json:"capabilities"`
 }
 
-// Capabilities defines which
-type Capabilities struct {
-	Input       bool `json:"input"`
-	Output      bool `json:"output"`
-	PWM         bool `json:"pwm"`
-	Temperature bool `json:"temperature"`
-	PH          bool `json:"ph"`
+func (m Metadata) HasCapability(cap Capability) bool {
+	for _, c := range m.Capabilities {
+		if c == cap {
+			return true
+		}
+	}
+	return false
 }
 
 type Driver interface {

--- a/noop.go
+++ b/noop.go
@@ -19,15 +19,9 @@ type noopDriver struct{ meta Metadata }
 func NewNoopDriver() *noopDriver {
 	return &noopDriver{
 		meta: Metadata{
-			Name:        "noop-driver",
-			Description: "No operation (stub/null) hal driver for testing",
-			Capabilities: Capabilities{
-				Input:       true,
-				Output:      true,
-				PH:          true,
-				Temperature: true,
-				PWM:         true,
-			},
+			Name:         "noop-driver",
+			Description:  "No operation (stub/null) hal driver for testing",
+			Capabilities: []Capability{Input, Output, PH, Temperature, PWM},
 		},
 	}
 }


### PR DESCRIPTION
Lets use enums to represent different capabilities. With this we can avoid if else checks on the consumer side
```go
var d hal.Driver
if d.Metadata().HasCapability(hal.Input) {
 i, _ := d.(hal.InputDriver)
 pin, _ := i.InputPin("foo")
 pin.Read()
}
```