### PR TITLE
use int instead of string to denote i/o pin or pwm channel

### DIFF
--- a/adc.go
+++ b/adc.go
@@ -8,5 +8,5 @@ type ADCChannel interface {
 type ADCDriver interface {
 	Driver
 	ADCChannels() []ADCChannel
-	ADCChannel(name string) (ADCChannel, error)
+	ADCChannel(int) (ADCChannel, error)
 }

--- a/digital_io.go
+++ b/digital_io.go
@@ -21,7 +21,7 @@ type InputPin interface {
 type InputDriver interface {
 	Driver
 	InputPins() []InputPin
-	InputPin(name string) (InputPin, error)
+	InputPin(int) (InputPin, error)
 }
 
 type OutputPin interface {
@@ -33,5 +33,5 @@ type OutputPin interface {
 type OutputDriver interface {
 	Driver
 	OutputPins() []OutputPin
-	OutputPin(name string) (OutputPin, error)
+	OutputPin(int) (OutputPin, error)
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -17,7 +17,7 @@ func TestDriver(t *testing.T) {
 	if len(input.InputPins()) != 0 {
 		t.Error("Wrong input pins:", len(input.InputPins()))
 	}
-	pin, err := input.InputPin("GP4")
+	pin, err := input.InputPin(4)
 	if err != nil {
 		t.Error(err)
 	}
@@ -28,7 +28,7 @@ func TestDriver(t *testing.T) {
 	if len(output.OutputPins()) != 0 {
 		t.Error("Wrong output pins:", len(output.OutputPins()))
 	}
-	opin, perr := output.OutputPin("GP4")
+	opin, perr := output.OutputPin(4)
 	if perr != nil {
 		t.Error(perr)
 	}
@@ -41,7 +41,7 @@ func TestDriver(t *testing.T) {
 		t.Error("Wrong number of pwm channels: ", len(pwm.PWMChannels()))
 	}
 
-	ppin, nerr := pwm.PWMChannel("foo")
+	ppin, nerr := pwm.PWMChannel(1)
 	if nerr != nil {
 		t.Error(nerr)
 	}

--- a/noop.go
+++ b/noop.go
@@ -29,11 +29,11 @@ func NewNoopDriver() *noopDriver {
 		},
 	}
 }
-func (n *noopDriver) Metadata() Metadata                      { return n.meta }
-func (n *noopDriver) Close() error                            { return nil }
-func (n *noopDriver) InputPins() []InputPin                   { return []InputPin{} }
-func (n *noopDriver) OutputPins() []OutputPin                 { return []OutputPin{} }
-func (n *noopDriver) InputPin(_ string) (InputPin, error)     { return new(noopPin), nil }
-func (n *noopDriver) OutputPin(_ string) (OutputPin, error)   { return new(noopPin), nil }
-func (n *noopDriver) PWMChannels() []PWMChannel               { return []PWMChannel{} }
-func (n *noopDriver) PWMChannel(_ string) (PWMChannel, error) { return new(noopChannel), nil }
+func (n *noopDriver) Metadata() Metadata                   { return n.meta }
+func (n *noopDriver) Close() error                         { return nil }
+func (n *noopDriver) InputPins() []InputPin                { return []InputPin{} }
+func (n *noopDriver) OutputPins() []OutputPin              { return []OutputPin{} }
+func (n *noopDriver) InputPin(_ int) (InputPin, error)     { return new(noopPin), nil }
+func (n *noopDriver) OutputPin(_ int) (OutputPin, error)   { return new(noopPin), nil }
+func (n *noopDriver) PWMChannels() []PWMChannel            { return []PWMChannel{} }
+func (n *noopDriver) PWMChannel(_ int) (PWMChannel, error) { return new(noopChannel), nil }

--- a/pwm.go
+++ b/pwm.go
@@ -8,5 +8,5 @@ type PWMChannel interface {
 type PWMDriver interface {
 	OutputDriver
 	PWMChannels() []PWMChannel
-	PWMChannel(name string) (PWMChannel, error)
+	PWMChannel(int) (PWMChannel, error)
 }


### PR DESCRIPTION
- Avoid unnecessary int to string conversion
- Dont need to come up with custom naming scheme (GP-* for pi )