### PR TITLE
Add a HAL interface for temperature channels

### DIFF
--- a/temperature.go
+++ b/temperature.go
@@ -1,0 +1,12 @@
+package hal
+
+type TemperatureChannel interface {
+	// Read returns a logical temperature in degrees celsius
+	ReadTemperature() (float64, error)
+}
+
+type TemperatureDriver interface {
+	Driver
+	TemperatureChannels() []TemperatureChannel
+	TemperatureChannel(int) (TemperatureChannel, error)
+}


### PR DESCRIPTION
This is for sensors which have any internal logic to
read degrees celsius from a sensor. Useful for digital sensors,
or other sensors already converted by some other system.

We should consider adding a method for conversion on any analog
input going forward, which a driver could also expose, but this
unblocks some other work.